### PR TITLE
Add target build_examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,3 +75,36 @@ add_subdirectory(tests)
 file(GLOB all_srcs CONFIGURE_DEPENDS "include/*.h" "src/*.cpp" "tests/*.cpp")
 add_custom_target(format ${CLANG_FORMAT} --style=file -i ${all_srcs})
 add_custom_target(format-check ${CLANG_FORMAT} --style=file ${all_srcs} --dry-run -Werror)
+
+# EXAMPLES BUILD
+set(bin_example_dir ${CMAKE_BINARY_DIR}/bin/examples)
+set(obj_example_dir ${CMAKE_BINARY_DIR}/bin/examples/obj)
+file(MAKE_DIRECTORY ${bin_example_dir})
+file(MAKE_DIRECTORY ${obj_example_dir})
+# Find all lang files in the examples directory
+file(GLOB example_sources CONFIGURE_DEPENDS "examples/*.lang")
+# Generate build commands for each example
+set(build_example_commands "")
+foreach(example_source ${example_sources})
+    # Get file name without file path and extension
+    get_filename_component(example_name ${example_source} NAME_WE)
+    # Generate object file
+    add_custom_command(
+        OUTPUT ${obj_example_dir}/${example_name}.obj
+        COMMAND ${CMAKE_BINARY_DIR}/bin/lang ${example_source} 
+                    -o ${obj_example_dir}/${example_name}.obj
+        DEPENDS ${example_source}
+    )
+    # Generate executable
+    add_custom_command(
+        OUTPUT ${bin_example_dir}/${example_name}
+        COMMAND clang ${obj_example_dir}/${example_name}.obj 
+                    -o ${bin_example_dir}/${example_name}
+        DEPENDS ${obj_example_dir}/${example_name}.obj
+    )
+    list(APPEND build_example_commands ${bin_example_dir}/${example_name})
+endforeach()
+add_custom_target(
+    build_examples
+    DEPENDS ${build_example_commands}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ foreach(example_source ${example_sources})
     # Generate executable
     add_custom_command(
         OUTPUT ${bin_example_dir}/${example_name}
-        COMMAND clang ${obj_example_dir}/${example_name}.obj 
+        COMMAND ${CMAKE_C_COMPILER} ${obj_example_dir}/${example_name}.obj 
                     -o ${bin_example_dir}/${example_name}
         DEPENDS ${obj_example_dir}/${example_name}.obj
     )


### PR DESCRIPTION
# Summary
Add a target that builds all the example into object files and executable files.

## Details
* Target will **not** included in regular build.
* examples/ and examples/obj directories is created when building the project for the first time.
* Here is what the output structure might look like in ./build/bin/
```bash
bin
└── examples
    ├── executable1
    ├── executable2
    └── obj
        ├── obj1
        └── obj2
```

## Usage
Currently, we must build ./bin/lang before using it.
```
ninja -j4
```
```
ninja build_examples
```
```
ninja clean
```

## Possible Improvements
* Currently if one of the example source has compilation error then the rest of the source won't be compile/linked.
* Currently, it requires the lang binary to work. We can build it when it's missing.