### PR TITLE
Revert the `mut` keyword

### DIFF
--- a/examples/alt-get-syntax.lang
+++ b/examples/alt-get-syntax.lang
@@ -16,7 +16,7 @@ def read_from_buff = \IO io [3 x [4 x char]] buff int x -> IO
     let newio = writeln(io buff[x])
     read_from_buff(newio buff ADD x 1)
 
-def write_to_buff = \mut GENERIC buff int x GENERIC s -> mut [3 x [4 x char]]
+def write_to_buff = \GENERIC buff int x GENERIC s -> [3 x [4 x char]]
   # The alternative SET syntax is
   #
   #   `<aggregate> [ <index> ] : <setvalue>`
@@ -28,7 +28,7 @@ def write_to_buff = \mut GENERIC buff int x GENERIC s -> mut [3 x [4 x char]]
   buff[x] : s
 
 def main = \IO io -> IO
-  let buff = zero as mut [3 x [4 x char]]
+  let buff = zero as [3 x [4 x char]]
   let buff2 = write_to_buff(buff 0 "abc")
   let buff3 = write_to_buff(buff2 1 "xyz")
   let buff4 = write_to_buff(buff3 2 "123")

--- a/examples/buffer.lang
+++ b/examples/buffer.lang
@@ -11,11 +11,11 @@ def read_from_buff = \IO io [3 x [4 x char]] buff int x -> IO
 
 # SET returns a new composite type of the same type as its first argument, but
 # with a transformation made to one of its elements.
-def write_to_buff = \mut GENERIC buff int x GENERIC s -> mut [3 x [4 x char]]
+def write_to_buff = \GENERIC buff int x GENERIC s -> [3 x [4 x char]]
   SET buff x s
 
 def main = \IO io -> IO
-  let buff = zero as mut [3 x [4 x char]]
+  let buff = zero as [3 x [4 x char]]
   let buff2 = write_to_buff(buff 0 "abc")
   let buff3 = write_to_buff(buff2 1 "xyz")
   let buff4 = write_to_buff(buff3 2 "123")

--- a/examples/buffer2.lang
+++ b/examples/buffer2.lang
@@ -12,12 +12,12 @@ def read_from_buff = \IO io [3 x [4 x char]] buff int x -> IO
 def func = \[4 x char] s bool cond -> [4 x char]
   if cond s else zero as [4 x char]
 
-def write_to_buff = \mut GENERIC buff int x [4 x char] s bool cond -> mut [3 x [4 x char]]
+def write_to_buff = \GENERIC buff int x [4 x char] s bool cond -> [3 x [4 x char]]
   let v = func(s cond)
   SET buff x v
 
 def main = \IO io -> IO
-  let buff = zero as mut [3 x [4 x char]]
+  let buff = zero as [3 x [4 x char]]
   let buff2 = write_to_buff(buff 0 "abc" true)
   let buff3 = write_to_buff(buff2 1 "xyz" false)
   let buff4 = write_to_buff(buff3 2 "123" true)

--- a/examples/char-array-str.lang
+++ b/examples/char-array-str.lang
@@ -1,7 +1,7 @@
 # NOTE: `func` always returns the same value since it has no inputs, so 
 # this can effectively be evaluated at compile time.
 def func = \ -> <[128 x char]>
-  let chars = zero as mut [128 x char]
+  let chars = zero as [128 x char]
   let chars2 = SET chars 0 'a'
   let chars3 = SET chars2 1 'b'
   let chars4 = SET chars3 2 'c'

--- a/examples/compiler.lang
+++ b/examples/compiler.lang
@@ -61,7 +61,7 @@ typedef Lexer = {
   int col
 }
 
-#def getNextChar = \mut Lexer this -> <mut Lexer int>
+#def getNextChar = \Lexer this -> <Lexer int>
 #  # TODO: Something like this might be nice
 #  #
 #  #   let this.io = readc(this.io)
@@ -131,8 +131,8 @@ def skip_ws = \IO io int old_row int old_col -> <IO int int int>
 # - The last read character
 # - The row of the last read character
 # - The col of the last read character
-def __read_token_remaining = \IO io mut [128 x char] buff int idx int old_row int old_col ->
-                              <mut [128 x char] IO int int int>
+def __read_token_remaining = \IO io [128 x char] buff int idx int old_row int old_col ->
+                              <[128 x char] IO int int int>
   let io2, c, row, col = readc_row_col(io old_row old_col)
   if any(LT c 0
          EQ CAST char c ' '
@@ -156,8 +156,8 @@ def __read_token_remaining = \IO io mut [128 x char] buff int idx int old_row in
 # - The last read character
 # - The row of the last read character
 # - The col of the last read character
-def __read_string_token = \IO io mut [128 x char] buff int idx int old_row int old_col ->
-                                <mut [128 x char] IO int int int>
+def __read_string_token = \IO io [128 x char] buff int idx int old_row int old_col ->
+                                <[128 x char] IO int int int>
   let io2, c, row, col = readc_row_col(io old_row old_col)
   if OR
        LT c 0
@@ -214,8 +214,8 @@ def __read_string_token = \IO io mut [128 x char] buff int idx int old_row int o
 # - The last read character
 # - The row of the last read character
 # - The col of the last read character
-def __read_string_token = \IO io int old_row int old_col -> <mut [128 x char] IO int int int>
-  let buff = zero as mut [128 x char]
+def __read_string_token = \IO io int old_row int old_col -> <[128 x char] IO int int int>
+  let buff = zero as [128 x char]
   __read_string_token(io buff 0 old_row old_col)
 
 # Arguments:
@@ -266,7 +266,7 @@ def read_token = \IO io int old_row int old_col -> <[128 x char] IO int int int>
       GET skip_comment_res 3)
   else
 
-  let buff = zero as mut [128 x char]
+  let buff = zero as [128 x char]
 
   let res =
     if LT c 0
@@ -746,7 +746,7 @@ def main = \IO io -> IO
   keep failed_to_write_io =
     writeln(io___13 "failed to write add.obj: " failed_to_write)
 
-  let err_buff = zero as mut [1024 x char]
+  let err_buff = zero as [1024 x char]
   let err_buff_ptr = <CAST cptr err_buff>
 
   keep failed_to_write_obj = impurecall LLVMTargetMachineEmitToFile

--- a/examples/read-all-tokens.lang
+++ b/examples/read-all-tokens.lang
@@ -22,7 +22,7 @@ def any = \bool a -> bool
 def any = \bool a GENERIC_REMAINING remaining -> bool
   OR a any(remaining)
 
-def __read_token_remaining = \IO io mut [128 x char] buff int idx -> <mut [128 x char] IO int>
+def __read_token_remaining = \IO io [128 x char] buff int idx -> <[128 x char] IO int>
   let res = readc(io)
   let io2 = GET res 0
   let c = GET res 1
@@ -35,7 +35,7 @@ def __read_token_remaining = \IO io mut [128 x char] buff int idx -> <mut [128 x
     let newbuff = SET buff idx CAST char c
     __read_token_remaining(io2 newbuff ADD idx 1)
 
-def __read_string_token = \IO io mut [128 x char] buff int idx -> <mut [128 x char] IO int>
+def __read_string_token = \IO io [128 x char] buff int idx -> <[128 x char] IO int>
   let next = readc(io)
   let next_IO = GET next 0
   let next_c = GET next 1
@@ -54,8 +54,8 @@ def __read_string_token = \IO io mut [128 x char] buff int idx -> <mut [128 x ch
     SET buff idx CAST char next_c
     ADD idx 1)
 
-def __read_string_token = \IO io -> <mut [128 x char] IO int>
-  let buff = zero as mut [128 x char]
+def __read_string_token = \IO io -> <[128 x char] IO int>
+  let buff = zero as [128 x char]
   let buff2 = SET buff 0 '"'
   __read_string_token(io buff2 1)
 
@@ -63,11 +63,11 @@ def __read_string_token = \IO io -> <mut [128 x char] IO int>
 #   - buffer of the original chars
 #   - IO
 #   - The last char read
-def read_token = \IO io int idx -> <mut [128 x char] IO int>
+def read_token = \IO io int idx -> <[128 x char] IO int>
   let skipped = skip_ws(io)
   let skipped_IO = GET skipped 0
   let last_c = GET skipped 1
-  let buff = zero as mut [128 x char]
+  let buff = zero as [128 x char]
   if LT last_c 0
     <buff skipped_IO last_c>
   else

--- a/examples/read-token.lang
+++ b/examples/read-token.lang
@@ -1,6 +1,5 @@
-def writeln_str = \IO io [128 x char] s -> IO
-  let io2 = write(io s)
-  write(io2 "\n")
+def writeln = \IO io GENERIC s -> IO
+  io.write(s).write("\n")
 
 def any = \bool a -> bool
   a
@@ -8,7 +7,7 @@ def any = \bool a -> bool
 def any = \bool a GENERIC_REMAINING remaining -> bool
   OR a any(remaining)
 
-def read_token = \IO io mut [128 x char] buff int idx -> <[128 x char] IO>
+def read_token = \IO io [128 x char] buff int idx -> <[128 x char] IO>
   let res = call readc io end
   let io2 = GET res 0
   let c = GET res 1
@@ -22,5 +21,5 @@ def read_token = \IO io mut [128 x char] buff int idx -> <[128 x char] IO>
     read_token(io2 newbuff ADD idx 1)
 
 def main = \IO io -> IO
-  let res = read_token(io zero as mut [128 x char] 0)
-  writeln_str(GET res 1 GET res 0)
+  let res = read_token(io zero as [128 x char] 0)
+  writeln(GET res 1 GET res 0)

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -34,7 +34,6 @@ class Token {
     TK_False,
     TK_Zero,
     TK_As,
-    TK_Mut,
     TK_Dot,          // .
     TK_Comma,        // ,
     TK_Colon,        // :

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -132,7 +132,7 @@ class Compiler {
   // Say we have a declaration:
   //
   //   decl func = \<comp-or-arr-type> a <integer> b <char array> c ->
-  //   <comp-or-arr-type>
+  //                <comp-or-arr-type>
   //
   // We need to determine the calling convention. How do we return composite or
   // array types? How do we know if we can mutate or SET any of the parameters?
@@ -145,21 +145,38 @@ class Compiler {
     // pointers, etc). No changes are needed for the function.
     ReturnNormalType,
 
-    // The return type should be void and instead the caller allocates a buffer
+    // The return type should be a pointer and the caller allocates a buffer
     // for enough space for the lang return type. The function is changed such
     // that a pointer to this buffer will be the actual return type and the
     // actual arguments come after it. This is reserved for array or composite
     // types.
-    ReturnAsFirstArg,
-
-    // The return type should be a pointer and the return value is just the
-    // first argument to the function. This is reserved for array and composite
-    // types where we know the only thing that changed is the first argument and
-    // we end up returning only the first argument.
     //
-    // NOTE: We can only do this if we know for sure the first argument is
-    // mutable (ie. not constant).
-    ReturnFirstArgInPlace,
+    // Given a signature:
+    //
+    //   decl func = \[4 x char] s bool cond -> [4 x char]
+    //
+    // we don't have a way to tell if the function does an alloca. It could be
+    //
+    //   def func = \[4 x char] s bool cond -> [4 x char]
+    //     if cond s else zero as [4 x char]
+    //
+    // which doesn't need an alloca before the call or
+    //
+    //   def func = \[4 x char] s bool cond -> [4 x char]
+    //     SET s 1 if cond 'a' 'b'
+    //
+    // which does need an alloca before the call. The all-encompassing case
+    // would be unconditionally assume an allocation is needed and bear the cost
+    // of the alloca. Runtime-wise, it shouldn't add any more instructions since
+    // all allocas are consolidated into a single stack pointer decrement. But
+    // this could result in a lot of unecessary stack usage for large objects.
+    // The alternative is we could have something like a unique_ptr and the
+    // actual object would be on the heap. The caller would only need to
+    // allocate space for the unique_ptr size which can be constant.
+    MayReturnFirstArg,
+
+    // TODO: We should have a special strategy for functions with no arguments.
+    // It should be possible to construct a global and just return that.
   };
 
   ReturnStrategy getCallableReturnStrategy(const CallableType &type) const {
@@ -170,14 +187,7 @@ class Compiler {
     if (!ret.isAggregateType())
       return ReturnNormalType;
 
-    // However, since this callable now owns all of the expressions passed it
-    // it, if the very first allocation has the exact same type as the return
-    // type, then we can just return the first argument as a pointer and make
-    // any local edits to that.
-    if (type.getNumArgs() > 0 && ret.CanConvertFrom(type.getArgType(0)))
-      return ReturnFirstArgInPlace;
-
-    return ReturnAsFirstArg;
+    return MayReturnFirstArg;
   }
 
   llvm::Function *getCPrintf() const;
@@ -198,7 +208,10 @@ class Compiler {
   // This exists to handle PHI nodes where calling Value::replaceAllUsesWith
   // doesn't also replace the incoming values of the phi node with the
   // replacement.
-  void ReplaceAllUsesWith(llvm::Value *replacement, llvm::Value *replacing);
+  //
+  // Returns the actual value the LLVM function should return.
+  llvm::Value *ReplaceAllocasWith(llvm::Value *replacement,
+                                  llvm::Value *replacing);
 
   // This also handles storing large data structures like composites or arrays
   // into pointers which will involve memcpys.
@@ -207,6 +220,46 @@ class Compiler {
 
   void FillFuncBody(const Callable &callable, llvm::Function *func,
                     std::string_view name);
+
+  // This should be checked whenever we want to do an alloca. If at any point we
+  // would want to alloca, we should attempt to reuse the first argument if we
+  // know the return strategy involves returning the first argument.
+  bool CanBeStorageForReturnValue(const Expr &callable_body,
+                                  const Expr &expr) const {
+    // These are the same expressions so the storage is the same.
+    if (&expr == &callable_body)
+      return true;
+
+    // If the types don't match, this can't possibly be what we return.
+    if (expr.getType() != callable_body.getType())
+      return false;
+
+    if (const auto *let = llvm::dyn_cast<Let>(&callable_body))
+      return CanBeStorageForReturnValue(let->getExpr(), expr);
+
+    if (const auto *keep = llvm::dyn_cast<Keep>(&callable_body))
+      return CanBeStorageForReturnValue(keep->getBody(), expr);
+
+    if (const auto *if_expr = llvm::dyn_cast<If>(&callable_body)) {
+      return CanBeStorageForReturnValue(if_expr->getIf(), expr) ||
+             CanBeStorageForReturnValue(if_expr->getElse(), expr);
+    }
+
+    return false;
+  }
+
+  llvm::Value *GetAllocaOrReturnValStorage(llvm::IRBuilder<> &builder,
+                                           const Expr &expr) {
+    ReturnStrategy return_strat =
+        getCallableReturnStrategy(this_callable_->getType());
+    if (return_strat == MayReturnFirstArg &&
+        CanBeStorageForReturnValue(this_callable_->getBody(), expr)) {
+      llvm::Function *func = llvm::cast<llvm::Function>(
+          processed_exprs_.find(this_callable_)->second);
+      return func->getArg(0);
+    }
+    return builder.CreateAlloca(getLLVMType(expr));
+  }
 
   llvm::DIType *getDIType(const Type &type) {
     switch (type.getKind()) {
@@ -224,6 +277,7 @@ class Compiler {
   std::unique_ptr<NamedType> io_type_;
   std::unique_ptr<NamedType> str_type_;
   std::map<const Node *, llvm::Value *> processed_exprs_;
+  const Callable *this_callable_ = nullptr;
   llvm::DIBuilder di_builder_;
   llvm::DIFile &di_unit_;
   llvm::DICompileUnit &di_cu_;
@@ -357,7 +411,7 @@ llvm::Value *Compiler::getDeclare(const Declare &declare) {
 // actual `main` then dispatch to this function.
 llvm::Function *Compiler::getMainWrapper(llvm::FunctionType *func_ty) const {
   llvm::Function *impl_func = llvm::Function::Create(
-      func_ty, llvm::Function::ExternalLinkage, "main_impl", mod_);
+      func_ty, llvm::Function::PrivateLinkage, "main_impl", mod_);
 
   llvm::FunctionType *main_func_ty =
       llvm::FunctionType::get(getIntType(32), {}, /*isVarArg=*/false);
@@ -379,7 +433,7 @@ llvm::Function *Compiler::getMainWrapper(llvm::FunctionType *func_ty) const {
 llvm::FunctionType *Compiler::getLLVMFuncType(const CallableType &ty) {
   std::vector<llvm::Type *> func_args;
   ReturnStrategy return_strat = getCallableReturnStrategy(ty);
-  if (return_strat == ReturnAsFirstArg) {
+  if (return_strat == MayReturnFirstArg) {
     // The return type of this function is too large to return in IR (such as a
     // composite type with many elements). So we should instead allocate the
     // buffer in the caller and the function is in charge of "returning" the
@@ -400,11 +454,10 @@ llvm::FunctionType *Compiler::getLLVMFuncType(const CallableType &ty) {
     }
     func_args.push_back(llvm_arg_ty);
   }
-  llvm::Type *ret_ty = return_strat == ReturnAsFirstArg
-                           ? llvm::Type::getVoidTy(mod_.getContext())
+  llvm::Type *ret_ty = return_strat == MayReturnFirstArg
+                           ? llvm::PointerType::getUnqual(mod_.getContext())
                            : getLLVMType(ty.getReturnType());
-  if (llvm::isa<CallableType>(ty.getReturnType()) ||
-      return_strat == ReturnFirstArgInPlace)
+  if (llvm::isa<CallableType>(ty.getReturnType()))
     ret_ty = llvm::PointerType::getUnqual(mod_.getContext());
   return llvm::FunctionType::get(ret_ty, func_args, /*isVarArg=*/false);
 }
@@ -492,21 +545,26 @@ llvm::Type *Compiler::getLLVMType(const NamedType &type) {
   UNREACHABLE("Unhandled type name: %s", type.getName().data());
 }
 
-void Compiler::ReplaceAllUsesWith(llvm::Value *replacement,
-                                  llvm::Value *replacing) {
+llvm::Value *Compiler::ReplaceAllocasWith(llvm::Value *replacement,
+                                          llvm::Value *replacing) {
   if (replacement == replacing)
-    return;
+    return replacement;
 
   // Do a normal replacement.
-  replacing->replaceAllUsesWith(replacement);
+  if (llvm::isa<llvm::AllocaInst>(replacing)) {
+    replacing->replaceAllUsesWith(replacement);
+    return replacement;
+  }
 
   // Doing a traditional Value::replaceAllUsesWith doesn't replace the incoming
   // values of the phi node with the replacement, so instead we need to manually
   // call RAUW on the incoming nodes. Then we can just delete the phi node.
   if (auto *phi = llvm::dyn_cast<llvm::PHINode>(replacing)) {
     for (llvm::Value *incoming : phi->incoming_values())
-      ReplaceAllUsesWith(replacement, incoming);
+      ReplaceAllocasWith(replacement, incoming);
   }
+
+  return replacing;
 }
 
 llvm::Value *Compiler::getCallable(llvm::IRBuilder<> &builder,
@@ -535,6 +593,9 @@ void Compiler::FillFuncBody(const Callable &callable, llvm::Function *func,
   assert(!processed_exprs_.contains(&callable));
   processed_exprs_.try_emplace(&callable, func);
 
+  const Callable *old_callable = this_callable_;
+  this_callable_ = &callable;
+
   const SourceLocation &start = callable.getStart();
   llvm::DISubprogram *SP = di_builder_.createFunction(
       &di_unit_, name, name, &di_unit_, start.getRow(),
@@ -545,11 +606,11 @@ void Compiler::FillFuncBody(const Callable &callable, llvm::Function *func,
 
   const CallableType &ty = callable.getType();
   ReturnStrategy return_strat = getCallableReturnStrategy(ty);
-  if (return_strat == ReturnAsFirstArg)
+  if (return_strat == MayReturnFirstArg)
     func->getArg(0)->setName("return_val");
 
   for (size_t i = 0; i < callable.getNumArgs(); ++i)
-    func->getArg(i + (return_strat == ReturnAsFirstArg))
+    func->getArg(i + (return_strat == MayReturnFirstArg))
         ->setName(callable.getArgName(i));
 
   // Create the function body.
@@ -560,19 +621,10 @@ void Compiler::FillFuncBody(const Callable &callable, llvm::Function *func,
   auto processed_exprs_cpy = processed_exprs_;
   llvm::Value *ret = getExpr(nested_builder, callable.getBody());
   processed_exprs_ = processed_exprs_cpy;
-  switch (return_strat) {
-    case ReturnAsFirstArg:
-      ReplaceAllUsesWith(func->getArg(0), ret);
-      nested_builder.CreateRetVoid();
-      break;
-    case ReturnNormalType:
-    case ReturnFirstArgInPlace:
-      assert(
-          !ResolvesToAlloca(ret) &&
-          "Returning a pointer to an alloca can result in a use-after-return");
-      nested_builder.CreateRet(ret);
-      break;
-  }
+
+  assert(!ResolvesToAlloca(ret) &&
+         "Returning a pointer to an alloca can result in a use-after-return");
+  nested_builder.CreateRet(ret);
 
   assert(func->getSubprogram());
   di_builder_.finalizeSubprogram(func->getSubprogram());
@@ -581,6 +633,8 @@ void Compiler::FillFuncBody(const Callable &callable, llvm::Function *func,
     func->print(llvm::errs());
     UNREACHABLE("Function for callable %p not well-formed", &callable);
   }
+
+  this_callable_ = old_callable;
 }
 
 llvm::Value *Compiler::getLet(llvm::IRBuilder<> &builder, const Let &let) {
@@ -697,7 +751,8 @@ llvm::Value *Compiler::getExprImpl(llvm::IRBuilder<> &builder,
       // This should've already been cached.
       llvm::Function *func =
           llvm::cast<llvm::Function>(processed_exprs_.at(&parent));
-      bool return_as_arg = func->getReturnType()->isVoidTy();
+      bool return_as_arg =
+          getCallableReturnStrategy(parent.getType()) == MayReturnFirstArg;
       return func->getArg(arg.getArgNo() + return_as_arg);
     }
     case Node::NK_Int:
@@ -806,7 +861,7 @@ llvm::Value *Compiler::getReadc(llvm::IRBuilder<> &builder,
     return func;
 
   auto *func_ty = llvm::cast<llvm::FunctionType>(getLLVMType(readc));
-  assert(func_ty->getReturnType()->isVoidTy());
+  assert(getCallableReturnStrategy(readc.getType()) == MayReturnFirstArg);
   assert(func_ty->getNumParams() == 2);
 
   llvm::Function *func = llvm::Function::Create(
@@ -826,22 +881,13 @@ llvm::Value *Compiler::getReadc(llvm::IRBuilder<> &builder,
   llvm::Value *gep = readc_builder.CreateConstGEP2_32(
       getLLVMType(readc.getType().getReturnType()), func->getArg(0), 0, 1);
   readc_builder.CreateStore(getc_call, gep);
-  readc_builder.CreateRetVoid();
+  readc_builder.CreateRet(func->getArg(0));
 
   return func;
 }
 
 llvm::Value *Compiler::getZero(llvm::IRBuilder<> &builder, const Zero &zero) {
   const Type &t = zero.getType();
-
-  if (t.isMutable()) {
-    // This is always mutable, so lets make it a stack allocation.
-    llvm::AllocaInst *alloc = builder.CreateAlloca(getLLVMType(zero));
-    size_t size = *alloc->getAllocationSize(mod_.getDataLayout());
-    builder.CreateMemSet(alloc, llvm::Constant::getNullValue(getIntType(8)),
-                         size, llvm::MaybeAlign());
-    return alloc;
-  }
 
   // These can be just constants.
   if (t.isAggregateType()) {
@@ -932,16 +978,21 @@ llvm::Value *Compiler::getGet(llvm::IRBuilder<> &builder, const Get &get) {
 
 llvm::Value *Compiler::getSet(llvm::IRBuilder<> &builder, const Set &set) {
   llvm::Value *expr = getExpr(builder, set.getExpr());
-  if (auto *glob = llvm::dyn_cast<llvm::GlobalVariable>(expr)) {
-    assert(!glob->isConstant() && "Attempting to store to a constant global");
-  }
   llvm::Type *expr_ty = getLLVMType(set.getExpr());
+
+  // Do a full memcpy before the store because this may be a new copy.
+  llvm::Value *alloc = GetAllocaOrReturnValStorage(builder, set);
+  size_t size = mod_.getDataLayout().getTypeAllocSize(expr_ty);
+  builder.CreateMemCpy(alloc, llvm::MaybeAlign(), expr, llvm::MaybeAlign(),
+                       size);
+
   llvm::Value *gep =
-      builder.CreateGEP(expr_ty, expr,
+      builder.CreateGEP(expr_ty, alloc,
                         {llvm::Constant::getNullValue(getIntType(32)),
                          getExpr(builder, set.getIdx())});
+
   DoStore(builder, gep, set.getStore());
-  return expr;
+  return alloc;
 }
 
 llvm::Value *Compiler::getCast(llvm::IRBuilder<> &builder, const Cast &cast) {
@@ -977,8 +1028,8 @@ llvm::Value *Compiler::getCast(llvm::IRBuilder<> &builder, const Cast &cast) {
 
       if (to_arr.getNumElems() > from_arr.getNumElems()) {
         // Create a copy of a larger size then return that.
-        llvm::AllocaInst *alloc = builder.CreateAlloca(llvm_to);
-        size_t to_size = *alloc->getAllocationSize(mod_.getDataLayout());
+        llvm::Value *alloc = GetAllocaOrReturnValStorage(builder, cast);
+        size_t to_size = mod_.getDataLayout().getTypeAllocSize(llvm_to);
         size_t from_size = mod_.getDataLayout().getTypeAllocSize(llvm_from);
         assert(to_size > from_size);
         builder.CreateMemSet(alloc, llvm::Constant::getNullValue(getIntType(8)),
@@ -1019,13 +1070,12 @@ llvm::Value *Compiler::getCall(llvm::IRBuilder<> &builder, const Call &call) {
   std::vector<llvm::Value *> args;
   const auto &func_type = llvm::cast<CallableType>(call.getFunc().getType());
   ReturnStrategy return_strat = getCallableReturnStrategy(func_type);
-  if (return_strat == ReturnAsFirstArg) {
+  if (return_strat == MayReturnFirstArg) {
     // The return type of this function is too large to return in IR (such as a
     // composite type with many elements). So we should instead allocate the
     // buffer in the caller and the function is in charge of "returning" the
     // value by initializing the first argument.
-    llvm::Value *alloc =
-        builder.CreateAlloca(getLLVMType(func_type.getReturnType()));
+    llvm::Value *alloc = GetAllocaOrReturnValStorage(builder, call);
     args.push_back(alloc);
   }
 
@@ -1044,7 +1094,7 @@ llvm::Value *Compiler::getCall(llvm::IRBuilder<> &builder, const Call &call) {
   ret->setDebugLoc(
       llvm::DILocation::get(di_unit_.getContext(), call.getStart().getRow(),
                             call.getStart().getCol(), func->getSubprogram()));
-  return return_strat == ReturnAsFirstArg ? args.front() : ret;
+  return ret;
 }
 
 void Compiler::DoStore(llvm::IRBuilder<> &builder, llvm::Value *store_ptr,
@@ -1064,10 +1114,11 @@ llvm::Value *Compiler::getStruct(llvm::IRBuilder<> &builder, const Struct &s) {
   llvm::StructType *llvm_ty = llvm::cast<llvm::StructType>(getLLVMType(t));
   auto &field_layout = cached_ordered_fields_.at(&t);
 
-  // if (t.isMutable()) {
-  //  This is always mutable, so lets make it a stack allocation.
-  llvm::Value *alloc = builder.CreateAlloca(llvm_ty);
-
+  // Since the struct elements may not be constant, we can instead just
+  // alloca our structure.
+  //
+  // TODO: If the type is immutable, we should emit a constant global instead.
+  llvm::Value *alloc = GetAllocaOrReturnValStorage(builder, s);
   for (size_t i = 0; i < field_layout.size(); ++i) {
     std::string_view name = field_layout.at(i).first;
     const Expr &e = s.getField(name);
@@ -1075,19 +1126,6 @@ llvm::Value *Compiler::getStruct(llvm::IRBuilder<> &builder, const Struct &s) {
     DoStore(builder, ptr, e);
   }
   return alloc;
-  //}
-
-  // FIXME: We can only use a Constant here if we know this value is evaluatable
-  // at compile time, but we don't have any way to support that.
-  //
-  //// This is a constant, so we can just create a global variable.
-  // auto *glob = llvm::ConstantStruct::get(llvm_ty, );
-  // auto *initializer = llvm::Constant::getNullValue(getLLVMType(t));
-  // auto *glob =
-  //     new llvm::GlobalVariable(mod_, getLLVMType(t), /*isConstant=*/true,
-  //                              /*Linkage=*/llvm::GlobalValue::ExternalLinkage,
-  //                              initializer, /*name=*/"");
-  // return glob;
 }
 
 llvm::Value *Compiler::getComposite(llvm::IRBuilder<> &builder,
@@ -1097,7 +1135,7 @@ llvm::Value *Compiler::getComposite(llvm::IRBuilder<> &builder,
   //
   // TODO: If the type is immutable, we should emit a constant global instead.
   llvm::Type *comp_ty = getLLVMType(comp);
-  llvm::Value *buff = builder.CreateAlloca(comp_ty);
+  llvm::Value *buff = GetAllocaOrReturnValStorage(builder, comp);
   for (size_t i = 0; i < comp.getNumElems(); ++i) {
     const Expr &elem = comp.getElem(i);
     llvm::Value *ptr = builder.CreateConstGEP2_32(comp_ty, buff, 0, i);

--- a/src/lang.cpp
+++ b/src/lang.cpp
@@ -20,6 +20,9 @@ int main(int argc, char **argv) {
   argparser.AddOptArg<bool>("sanitize-address").setStoreTrue();
   argparser.AddOptArg("output", 'o');
 
+  if (argparser.CheckAndMaybePrintHelp())
+    return 0;
+
   auto f = argparser.get("file");
   if (!f)
     return 1;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -23,7 +23,6 @@ const std::map<std::string, Token::TokenKind> kKeywordMap{
     {"let", Token::TK_Let},
     {"keep", Token::TK_Keep},
     {"as", Token::TK_As},
-    {"mut", Token::TK_Mut},
     {"zero", Token::TK_Zero},
     {"if", Token::TK_If},
     {"else", Token::TK_Else},

--- a/tests/testparser.cpp
+++ b/tests/testparser.cpp
@@ -73,15 +73,15 @@ TEST(Errors, VariadicMultipleCallableOverrides) {
 
 TEST(Errors, NonCompileTimeIdxSet) {
   constexpr std::string_view kExpectedError =
-      "1:40: Indexing a composite type requires a compile-time constant "
+      "1:36: Indexing a composite type requires a compile-time constant "
       "integer\n"
-      "def func = \\mut <int> b int x -> <int> SET b x 0\n"
-      "                                       ^\n"
-      "1:29: Index declared here\n"
-      "def func = \\mut <int> b int x -> <int> SET b x 0\n"
-      "                            ^";
+      "def func = \\<int> b int x -> <int> SET b x 0\n"
+      "                                   ^\n"
+      "1:25: Index declared here\n"
+      "def func = \\<int> b int x -> <int> SET b x 0\n"
+      "                        ^";
   std::stringstream input;
-  input << "def func = \\mut <int> b int x -> <int> SET b x 0";
+  input << "def func = \\<int> b int x -> <int> SET b x 0";
   TestParseError(input, kExpectedError);
 }
 


### PR DESCRIPTION
Having it requires handling a lot more semantics on the language level that I don't want to manage. One of the things I'd like is not exposing anything regarding mutability or storage to the language. The primary reason for having mutability had to do with reusing `alloca`s to avoid excess memcpys when calling functions that returned aggregate types, but LLVM has an optimization that takes care of this. That is, if all uses of an alloca occur before the first use of another alloca that's the same size and type, then the pass will remove the second alloca and reuse the first one.

Also add --help to the arg parser.